### PR TITLE
Organize links

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -41,16 +41,16 @@
 
           <!-- Organization Links -->
           <div class="column">
-            <?php if ($footer->hasRightNavigation()) : ?>
-            <h3><?php echo $footer->rightNavigation->title; ?></h3>
+            <h3>Organize</h3>
             <ul>
-              <?php foreach ($footer->rightNavigation->items as $item) : ?>
-                <li>
-                  <a href="<?php echo $item->url; ?>"><?php echo $item->title; ?></a>
-                </li>
-              <?php endforeach; ?>
+              <li><a href="https://secure.actblue.com/contribute/page/lets-go-bernie" title="Donate to the Bernie Sanders campaign">Contribute</a></li>
+              <li><a href="https://go.berniesanders.com/page/s/join" title="Sign Up to receive updates about Bernie Sanders's campign">Sign Up</a></li>
+              <li><a href="https://go.berniesanders.com/page/signup/volunteer-for-bernie" title="Volunteer to help Bernie Sander's campaign">Volunteer</a></li>
+              <li><a href="https://go.berniesanders.com/page/event/search_simple" title="Find an event to attend in support of Bernie Sanders">Events</a></li>
+              <li><a href="https://berniesanders.com/organize/" title="Organize an event">Organizing Hub</a></li>
+              <li><a href="https://store.berniesanders.com/" title="Purchase Bernie Sanders merchandise">Store</a></li>
+              <li><a href="https://berniesanders.com/jobswithbernie2016/" title="Find a job with the Bernie Sanders campaign">Jobs</a></li>
             </ul>
-            <?php endif; ?>
           </div>
           <!-- end: Oragnization Links -->
 

--- a/lib/init.php
+++ b/lib/init.php
@@ -24,8 +24,7 @@ add_action('widgets_init', __NAMESPACE__ . '\\widgets_init');
 function nav_menus_init() {
   register_nav_menus(array(
     'header' => 'Site Navigation',
-    'footer_social' => 'Social Links',
-    'footer_organize' => 'Organize Links'
+    'footer_social' => 'Social Links'
   ));
 }
 add_action('init', __NAMESPACE__ . '\\nav_menus_init');

--- a/lib/models/footer.php
+++ b/lib/models/footer.php
@@ -4,23 +4,16 @@ namespace SandersForPresident\Wordpress\Models;
 
 class FooterModel extends BaseModel {
   const LEFT_NAVIGATION_SLUG = 'footer_social';
-  const RIGHT_NAVIGATION_SLUG = 'footer_organize';
 
   public $leftNavigation;
-  public $rightNavigation;
 
   public function __construct() {
     $this->navLocations = get_nav_menu_locations();
     $this->prepareLeftNavigation();
-    $this->prepareRightNavigation();
   }
 
   public function hasLeftNavigation() {
     return !empty($this->leftNavigation);
-  }
-
-  public function hasRightNavigation() {
-    return !empty($this->rightNavigation);
   }
 
   public function prepareLeftNavigation() {
@@ -30,18 +23,6 @@ class FooterModel extends BaseModel {
     $menu = wp_get_nav_menu_object($this->navLocations[self::LEFT_NAVIGATION_SLUG]);
     $menuItems = wp_get_nav_menu_items($menu->term_id);
     $this->fillModelAttributes($this->leftNavigation, array(
-      'title' => $menu->name,
-      'items' => $menuItems
-    ));
-  }
-
-  public function prepareRightNavigation() {
-    if (!array_key_exists(self::RIGHT_NAVIGATION_SLUG, $this->navLocations)) {
-      return;
-    }
-    $menu = wp_get_nav_menu_object($this->navLocations[self::RIGHT_NAVIGATION_SLUG]);
-    $menuItems = wp_get_nav_menu_items($menu->term_id);
-    $this->fillModelAttributes($this->rightNavigation, array(
       'title' => $menu->name,
       'items' => $menuItems
     ));


### PR DESCRIPTION
Decided to remove the organize links from being managed in the WordPress dashboard. No need. We know what we want down here, same as what the campaign site has.

Moderators can manage their social links, we'll leave the other 2 as static lists.
