### PR TITLE
fix pubDate to return utc

### DIFF
--- a/lib/models/news/local_news_article.php
+++ b/lib/models/news/local_news_article.php
@@ -19,7 +19,9 @@ class LocalNewsArticle extends AbstractNewsArticle {
   }
 
   public function getDate() {
-    return $this->post->post_modified;
+      $t = $this->post->post_date_gmt;
+      // make sure it looks like a UTC datetime.
+      return substr($t,0,10).'T'.substr($t,11).'Z';
   }
 
   public function getLink() {


### PR DESCRIPTION
Now uses post_date_gmt and reformats it from mysql to iso 8601.

This fixes a problem with sorting articles. The admin can more easily force the local article to the top of the page by setting the date after the latest remote story.
